### PR TITLE
Remove dock icon.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A clipboard manager for Zazu.",
   "main": "monitor.js",
   "dependencies": {
+    "deasync": "^0.1.7",
     "electron-prebuilt": "^1.2.0",
     "nedb": "^1.8.0"
   },

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,9 +1,11 @@
 'use strict'
 
-const clipboard = require('electron').clipboard
-const nativeImage = require('electron').nativeImage
+const electron = require('electron')
 const readableFormat = require('./lib/readableFormat')
 const CappedCollection = require('./lib/cappedCollection')
+
+
+const { clipboard, nativeImage } = electron
 
 const clipCollection = new CappedCollection('clipCollection', 50)
 
@@ -11,25 +13,31 @@ const clipCollection = new CappedCollection('clipCollection', 50)
  * Checks to see if the current item in your clipboard should be added to the
  * capped collection or not. If so, adds it.
  */
-clipCollection.last().then((lastClip) => {
-  const clip = {}
-  clip.type = clipboard.readImage().isEmpty() ? 'text' : 'image'
+electron.app.on('will-quit', () => {
+  clipCollection.last().then((lastClip) => {
+    const clip = {}
+    clip.type = clipboard.readImage().isEmpty() ? 'text' : 'image'
 
-  if (clip.type === 'image') {
-    const image = clipboard.readImage()
-    const dimensions = image.getSize()
-    const size = readableFormat(image.toDataURL().length * 0.75)
-    clip.title = `Image: ${dimensions.width}x${dimensions.height} (${size.value}${size.unit})`
-    clip.raw = image.toDataURL()
-  } else {
-    clip.raw = clipboard.readText()
-  }
-  if (!lastClip || lastClip.type !== clip.type || lastClip.raw !== clip.raw) {
-    return clipCollection.insert(clip)
-  }
-}).then(() => {
-  process.exit(0)
-}).catch((err) => {
-  console.log(err, err.stack)
-  process.exit(1)
+    if (clip.type === 'image') {
+      const image = clipboard.readImage()
+      const dimensions = image.getSize()
+      const size = readableFormat(image.toDataURL().length * 0.75)
+      clip.title = `Image: ${dimensions.width}x${dimensions.height} (${size.value}${size.unit})`
+      clip.raw = image.toDataURL()
+    } else {
+      clip.raw = clipboard.readText()
+    }
+    if (!lastClip || lastClip.type !== clip.type || lastClip.raw !== clip.raw) {
+      return clipCollection.insert(clip)
+    }
+  }).then(() => {
+    process.exit(0)
+  }).catch((err) => {
+    console.log(err, err.stack)
+    process.exit(1)
+  })
+  require('deasync').loopWhile(() => true)
 })
+
+console.log('going')
+electron.app.quit()


### PR DESCRIPTION
This kills the electron application as soon as it starts without any
delay, so the dock icon never appears.

Otherwise, running this multiple times would cause a flickering in the
dock icon.

This works by closing electron, which usually also kills the process,
but we hook into the `will-close` and prevent it from closing using
`deasync`.
