### PR TITLE
Store the images externally to improve performance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+    "extends": ["standard"],
+    "rules": { "comma-dangle": [2, "always-multiline"] },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true,
+        },
+    },
+    "globals": {
+        "Mousetrap": true,
+        "newrelic": true,
+        "__nr_require": true,
+    },
+    "env": {
+        "browser": true,
+        "node": true,
+        "es6": true,
+        "mocha": true,
+        "node": true,
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.nedb
+data

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
   "dependencies": {
     "color": "^0.11.3",
     "js-htmlencode": "^0.2.0",
+    "mkdirp": "^0.5.1",
     "nedb": "^1.8.0",
     "s-ago": "^1.1.0"
   },
   "scripts": {
+    "lint": "eslint .",
+    "prepush": "npm run lint && npm test",
     "test": "mocha ./test"
   },
   "repository": {
@@ -31,6 +34,11 @@
   "homepage": "https://github.com/tinytacoteam/zazu-clipboard#readme",
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.5.3"
+    "eslint": "^3.15.0",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.2",
+    "eslint-plugin-standard": "^2.0.1",
+    "mocha": "^2.5.3",
+    "rimraf": "^2.5.4"
   }
 }

--- a/src/copy.js
+++ b/src/copy.js
@@ -11,7 +11,7 @@ module.exports = (pluginContext) => {
     return clipCollection.findOne(id).then((clip) => {
       if (clip.type === 'text') {
         clipboard.writeText(clip.raw)
-      } else if(clip.type === 'image') {
+      } else if (clip.type === 'image') {
         const image = nativeImage.createFromDataURL(clip.raw)
         clipboard.writeImage(image)
       }

--- a/src/lib/cappedClient.js
+++ b/src/lib/cappedClient.js
@@ -1,11 +1,22 @@
+const fs = require('fs')
+const path = require('path')
 const CappedCollection = require('./cappedCollection')
 
 class CappedClient {
-  constructor (cwd, env) {
-    this.clipCollection = new CappedCollection('clipCollection', {
-      cwd,
-    })
+  constructor (cwd, env = {}, logger) {
+    this.cwd = cwd
+    this.clipCollection = new CappedCollection('clipCollection', { cwd })
     this.clipCollection.setSize(env.size || 50)
+    this.clipCollection.setOnRemove(doc => this.removeCacheImage(doc))
+    this.console = logger
+  }
+
+  log (level, message) {
+    if (this.console) {
+      this.console.log(level, message)
+    } else {
+      console.log(`${level}: ${message}`)
+    }
   }
 
   last () {
@@ -23,6 +34,34 @@ class CappedClient {
   all () {
     return this.clipCollection.all()
   }
+
+  removeCacheImage (clip) {
+    return new Promise((resolve, reject) => {
+      if (clip.raw) {
+        const f = path.join(this.cwd, clip.raw)
+        fs.access(f, fs.constants.R_OK | fs.constants.W_OK, (err) => {
+          if (err) {
+            //  We don't want to stop the execution for error
+            //  so, output error log and continue
+            this.log('error', `'${clip.name}': ${err}`)
+            resolve()
+          } else {
+            fs.unlink(f, (err) => {
+              if (err) {
+                this.log('error', `'${clip.name}': ${err}`)
+                resolve()
+              } else {
+                resolve(f)
+              }
+            })
+          }
+        })
+      } else {
+        this.log('error', `clip.raw is empty for '${clip.name}'`)
+        resolve()
+      }
+    })
+  }
 }
 
 var client = null
@@ -32,5 +71,8 @@ module.exports = {
       client = new CappedClient(cwd, env)
     }
     return client
+  },
+  clear: () => {
+    client = null
   },
 }

--- a/src/lib/cappedCollection.js
+++ b/src/lib/cappedCollection.js
@@ -2,80 +2,100 @@ const Datastore = require('nedb')
 const path = require('path')
 
 class CappedCollection {
-  constructor (name, options) {
+  constructor (name, options = {}) {
     this.MAX_SIZE = 99999
     this.collection = new Datastore({
-      filename: path.join(options.cwd, 'data', name + '.nedb'),
+      filename: path.join(options.cwd || '', 'data', name + '.nedb'),
       autoload: true,
     })
   }
 
-  setSize(size) {
+  setSize (size) {
     this.MAX_SIZE = size
   }
 
   last () {
-    return new Promise((accept, reject) => {
-      return this.collection
+    return new Promise((resolve, reject) => {
+      this.collection
         .findOne({})
         .sort({ createdAt: -1 })
-        .exec((err, docs) => {
-          err ? reject(err) : accept(docs)
-        })
+        .exec((err, docs) => err ? reject(err) : resolve(docs))
     })
   }
 
   findOne (_id) {
-    return new Promise((accept, reject) => {
-      return this.collection.findOne({_id})
-        .exec((err, doc) => {
-          err ? reject(err) : accept(doc)
-        })
+    return new Promise((resolve, reject) => {
+      this.collection
+        .findOne({ _id })
+        .exec((err, doc) => err ? reject(err) : resolve(doc))
     })
   }
 
   upsert (doc, userOptions) {
-    const options = Object.assign({}, {
-      multi: false,
-      upsert: true,
-    }, userOptions)
-    const compiledDoc = Object.assign({}, {
-      createdAt: new Date()
-    }, doc)
-    return new Promise((accept, reject) => {
-      this.collection.update(doc, compiledDoc, options, (err, numReplaced) => {
-        err ? reject(err) : accept(numReplaced)
-      })
-    }).then(() => {
-      return this.reduce()
-    })
+    const options = Object.assign({}, { multi: false, upsert: true }, userOptions)
+    const compiledDoc = Object.assign({}, { createdAt: new Date() }, doc)
+    return new Promise((resolve, reject) => {
+      this.collection.update(
+        doc,
+        compiledDoc,
+        options,
+        (err, numReplaced) => err ? reject(err) : resolve(numReplaced))
+    }).then(() => this.reduce())
   }
 
   all () {
-    return new Promise((accept, reject) => {
-      return this.collection
+    return new Promise((resolve, reject) => {
+      this.collection
         .find({})
         .sort({ createdAt: -1 })
-        .exec((err, docs) => {
-          err ? reject(err) : accept(docs)
-        })
+        .exec((err, docs) => err ? reject(err) : resolve(docs))
+    })
+  }
+
+  setOnRemove (callback) {
+    this.onRemove = callback
+  }
+
+  clearOnRemove () {
+    this.onRemove = null
+  }
+
+  handleOnRemove (ids, callback) {
+    return new Promise((resolve, reject) => {
+      if (callback) {
+        this.collection
+          .find({ _id: { $in: ids } })
+          .exec((err, docs) => {
+            if (err) {
+              reject(err)
+            } else {
+              //  the 'callback()' should return a Promise
+              resolve(Promise.all(docs.map(doc => callback(doc))).then(() => ids))
+            }
+          })
+      } else {
+        resolve(ids)
+      }
     })
   }
 
   remove (ids) {
-    return new Promise((accept, reject) => {
-      this.collection.remove({ _id: { $in: ids } }, { multi: true }, (err, num) => {
-        err ? reject(err) : accept(num)
-      })
-    })
+    return this.handleOnRemove(ids, this.onRemove)
+      .then(ids => new Promise((resolve, reject) => {
+        this.collection.remove(
+          { _id: { $in: ids } },
+          { multi: true },
+          (err, num) => err ? reject(err) : resolve(num))
+      }))
   }
 
   reduce () {
-    return this.all().then((docs) => {
-      const excessDocs = docs.reverse().slice(0, Math.max(0, docs.length - this.MAX_SIZE))
-      const excessIds = excessDocs.map((doc) => doc._id)
-      return this.remove(excessIds)
-    })
+    return this.all()
+      .then((docs) => {
+        const excessDocs = docs.reverse().slice(0, Math.max(0, docs.length - this.MAX_SIZE))
+        const excessIds = excessDocs.map((doc) => doc._id)
+        return this.remove(excessIds)
+      })
   }
 }
 

--- a/src/lib/ipc.js
+++ b/src/lib/ipc.js
@@ -3,4 +3,4 @@ const EventEmitter = require('events')
 class MyEmitter extends EventEmitter {
 }
 
-module.exports = new MyEmitter
+module.exports = new MyEmitter()

--- a/src/lib/present.js
+++ b/src/lib/present.js
@@ -1,8 +1,11 @@
 const ago = require('s-ago')
 const Color = require('color')
 const { htmlEncode } = require('js-htmlencode')
+const path = require('path')
+const fs = require('fs')
 
-module.exports = (allClips) => {
+module.exports = (allClips, options = {}) => {
+  const { cwd } = options
   return allClips.map((clip) => {
     if (clip.type === 'text') {
       const isHexColor = clip.raw.match(/^#([0-9a-f]{3}){1,2}$/i)
@@ -12,7 +15,7 @@ module.exports = (allClips) => {
         preview: `
           <pre class='text'>${htmlEncode(clip.raw)}</pre>
           <div class='meta'>${ago(new Date(clip.createdAt))}<br />${clip.raw.length} characters</div>
-        `
+        `,
       }
       if (isHexColor) {
         const color = new Color(clip.raw)
@@ -27,12 +30,24 @@ module.exports = (allClips) => {
         `
       }
       return response
-    } else if(clip.type === 'image') {
+    } else if (clip.type === 'image') {
+      let imageSrc = clip.raw
+      let icon
+      if (clip.raw.indexOf(path.join('data', 'image')) === 0) {
+        //  if 'clip.raw' is a path instead of DataURL, then prefixed the plugin path to get full path
+        const imageFile = path.join(cwd || '', clip.raw)
+        //  Load the image and converted to DataURL format for <iframe> content
+        const imageData = fs.readFileSync(imageFile)
+        imageSrc = `data:image/png;base64,${imageData.toString('base64')}`
+        //  Let icon be the image file
+        icon = imageFile
+      }
       return {
+        icon,
         title: clip.title,
         value: clip._id,
         preview: `
-          <img src='${clip.raw}' />
+          <img src='${imageSrc}' />
           <div class='meta'>${ago(new Date(clip.createdAt))}</div>
         `,
       }

--- a/src/lib/readableFormat.js
+++ b/src/lib/readableFormat.js
@@ -1,5 +1,5 @@
-function readableFormat(value) {
-  var unitNames = ['b', 'kb', 'mb', 'gb', 'tb', 'pb', 'eb', 'zb']
+function readableFormat (value) {
+  var unitNames = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
   var unitIndex = 0
 
   while (value > 1000) {
@@ -12,7 +12,7 @@ function readableFormat(value) {
   }
 }
 
-function threeDigitPrecision(value) {
+function threeDigitPrecision (value) {
   if (value < 10) {
     return Math.round(value * 100) / 100
   } else if (value < 100) {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,8 +1,14 @@
 const readableFormat = require('./lib/readableFormat')
 const CappedClient = require('./lib/cappedClient')
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+const mkdirp = require('mkdirp')
 
 module.exports = (pluginContext) => {
   const { cwd, clipboard } = pluginContext
+
+  const sha1 = (message) => crypto.createHash('sha1').update(message).digest().toString('hex')
 
   const isTransient = () => {
     const badTypes = [
@@ -24,19 +30,59 @@ module.exports = (pluginContext) => {
     if (ignoreImages) {
       clip.type = 'text'
     } else {
-      clip.type = clipboard.readImage().isEmpty() ? 'text' : 'image'
+      clip.image = clipboard.readImage()
+      clip.type = clip.image.isEmpty() ? 'text' : 'image'
     }
 
     if (clip.type === 'image') {
-      const image = clipboard.readImage()
-      const dimensions = image.getSize()
-      const size = readableFormat(image.toDataURL().length * 0.75)
-      clip.title = `Image: ${dimensions.width}x${dimensions.height} (${size.value}${size.unit})`
-      clip.raw = image.toDataURL()
-    } else {
-      clip.raw = clipboard.readText()
+      //  For image, the 'clip.raw' is its persistent file location
+      clip.raw = path.join('data', 'images', `${Date.now()}.jpeg`)
+      //  Generate hash for later comparison
+      if (process.platform === 'win32' || process.platform === 'darwin') {
+        //  We use getBitmap() for hashing which is fastest
+        clip.hash = sha1(clip.image.getBitmap())
+      } else {
+        //  For Linux system, we use toDataURL() for hashing,
+        //  as getBitmap() and toBitmap() is quite slow on Linux.
+        clip.hash = sha1(clip.image.toDataURL())
+      }
+      return clip
     }
+
+    clip.raw = clipboard.readText()
+    clip.hash = sha1(clip.raw)
+    delete clip.image
     return clip
+  }
+
+  const processImage = (clip) => {
+    if (clip.type !== 'image' || clip.raw.length === 0 || !clip.image) {
+      return
+    }
+
+    // Although toPNG()'s performance isn't good, it's better than toDataURL(), and support transparency.
+    const imageData = clip.image.toPNG()
+
+    //  Create base directory if it doesn't exist.
+    const f = path.join(cwd, clip.raw)
+    const basedir = path.dirname(f)
+    if (!fs.existsSync(basedir)) {
+      mkdirp(basedir)
+    }
+
+    //  Save the image to disk
+    fs.writeFile(f, imageData, err => {
+      if (err) {
+        console.log('error', `ERROR: Failed to save image: ${clip.raw}\n\t ${err}`)
+      } else {
+        console.log('info', `Successfully saved image: ${clip.raw}`)
+      }
+    })
+
+    //  Generate title based on the image's dimension and size
+    const dimensions = clip.image.getSize()
+    const size = readableFormat(imageData.length)
+    clip.title = `Image: ${dimensions.width}x${dimensions.height} (${size.value}${size.unit})`
   }
 
   let lastClip
@@ -46,8 +92,14 @@ module.exports = (pluginContext) => {
         resolve()
       } else {
         const clip = getClip(env.ignoreImages)
-        if (!lastClip || lastClip.type !== clip.type || lastClip.raw !== clip.raw) {
+        //  Check if it's new clip
+        if (clip.raw.length > 0 && (!lastClip || lastClip.type !== clip.type || lastClip.hash !== clip.hash)) {
+          if (clip.type === 'image') {
+            //  process image clip first
+            processImage(clip)
+          }
           lastClip = clip
+          //  Add to database
           const clipCollection = CappedClient.init(cwd, env)
           resolve(clipCollection.upsert(clip))
         } else {
@@ -65,20 +117,23 @@ module.exports = (pluginContext) => {
   //  default minimum plugin system interval 100ms, for less CPU intense.
   const MINIMUM_INTERVAL = 250
 
+  //  interval value check
+  const parseInterval = (updateInterval) => {
+    const interval = parseInt(updateInterval, 10)
+    if (isNaN(interval)) {
+      return DEFAULT_INTERVAL
+    } else if (interval < MINIMUM_INTERVAL) {
+      return MINIMUM_INTERVAL
+    } else {
+      return interval
+    }
+  }
+
   //  We use a loop here to provide user the ability to customize the interval.
   //  it will keep looping unless got an exception.
   const start = (env = {}) => new Promise((resolve) => {
-      //  interval value check
-      let interval = parseInt(env.updateInterval, 10)
-      if (isNaN(interval)) {
-        interval = DEFAULT_INTERVAL
-      } else if (interval < MINIMUM_INTERVAL) {
-        interval = MINIMUM_INTERVAL
-      }
-      setTimeout(resolve, interval)
-    })
-    .then(() => monitor(env))
-    .then(() => start(env))
+    setTimeout(resolve, parseInterval(env.updateInterval))
+  }).then(() => monitor(env)).then(() => start(env))
 
   return start
 }

--- a/src/search.js
+++ b/src/search.js
@@ -4,13 +4,7 @@ const present = require('./lib/present')
 
 module.exports = (pluginContext) => {
   const { cwd } = pluginContext
-  return (query, env = {}) => {
-    const clipCollection = CappedClient.init(cwd, env)
-
-    return clipCollection.all().then((allClips) => {
-      return search(query, allClips)
-    }).then((sortedClips) => {
-      return present(sortedClips)
-    })
-  }
+  return (query, env = {}) => CappedClient.init(cwd, env).all()
+    .then((allClips) => search(query, allClips))
+    .then((sortedClips) => present(sortedClips, pluginContext))
 }

--- a/test/cappedClient.spec.js
+++ b/test/cappedClient.spec.js
@@ -1,0 +1,170 @@
+'use strict'
+
+const expect = require('chai').expect
+const fs = require('fs')
+const path = require('path')
+const mkdirp = require('mkdirp')
+const rmdir = require('rimraf')
+const CappedClient = require('../src/lib/cappedClient')
+
+const getTempDir = () => path.join(__dirname, 'tmp', `${Date.now()}`)
+
+const touch = (f) => fs.closeSync(fs.openSync(f, 'w'))
+
+describe('CappedClient', () => {
+  before(() => {
+    CappedClient.clear()
+  })
+  after((done) => {
+    CappedClient.clear()
+    rmdir(path.join(__dirname, 'tmp'), done)
+  })
+
+  describe('constructor', () => {
+    afterEach(() => {
+      CappedClient.clear()
+    })
+    it('default capped size should be 50', () => {
+      const client = CappedClient.init(getTempDir())
+      expect(client.clipCollection.MAX_SIZE).to.be.eq(50)
+    })
+    it('can assign a capped size', () => {
+      const client = CappedClient.init(getTempDir(), { size: 123 })
+      expect(client.clipCollection.MAX_SIZE).to.be.eq(123)
+    })
+  })
+  describe('given a full capped client of 5 items', () => {
+    let subject
+    beforeEach((done) => {
+      subject = CappedClient.init(getTempDir(), { size: 5 })
+      subject
+        .upsert({
+          name: 'first',
+          raw: path.join('images', '1.jpg'),
+          createdAt: new Date(new Date() - 9 * 1000) })
+        .then(() => subject.upsert({
+          name: 'second',
+          raw: path.join('images', '2.jpg'),
+          createdAt: new Date(new Date() - 8 * 1000) }))
+        .then(() => subject.upsert({
+          name: 'third',
+          raw: path.join('images', '3.jpg'),
+          createdAt: new Date(new Date() - 7 * 1000) }))
+        .then(() => subject.upsert({
+          name: 'fourth',
+          raw: path.join('images', '4.jpg'),
+          createdAt: new Date(new Date() - 6 * 1000) }))
+        .then(() => subject.upsert({
+          name: 'fifth',
+          raw: path.join('images', '5.jpg'),
+          createdAt: new Date(new Date() - 5 * 1000) }))
+        .then(() => {
+          mkdirp.sync(path.join(subject.cwd, 'images'))
+          touch(path.join(subject.cwd, 'images', '1.jpg'))
+          touch(path.join(subject.cwd, 'images', '2.jpg'))
+          touch(path.join(subject.cwd, 'images', '3.jpg'))
+          touch(path.join(subject.cwd, 'images', '4.jpg'))
+          touch(path.join(subject.cwd, 'images', '5.jpg'))
+        })
+        .then(() => done())
+        .catch(done)
+    })
+
+    afterEach((done) => {
+      subject.all()
+        .then((docs) => subject.clipCollection.remove(docs.map(doc => doc._id)))
+        .then(() => subject.all())
+        .then((docs) => {
+          expect(docs.length).to.eq(0)
+          CappedClient.clear()
+          done()
+        })
+        .catch(done)
+    })
+
+    describe('last', (done) => {
+      it('gives me back the last item added', (done) => {
+        subject.last()
+          .then((doc) => {
+            expect(doc).to.include({
+              name: 'fifth',
+            })
+            done()
+          })
+          .catch(done)
+      })
+    })
+
+    describe('capped', () => {
+      it('calling upsert() will trigger clipCollection.reduce() and remove the extra items', (done) => {
+        touch(path.join(subject.cwd, 'images', '6.jpg'))
+        subject.upsert({ name: 'sixth', raw: path.join('images', '6.jpg'), createdAt: new Date(new Date() - 3 * 1000) })
+          .then((nums) => {
+            expect(nums).to.be.eq(1)
+            return subject.all()
+          })
+          .then((docs) => {
+            expect(docs.length).to.be.eq(5)
+            expect(docs[docs.length - 1].name).to.be.eq('second')
+            return subject.last()
+          })
+          .then((doc) => {
+            //  the last one should be the new one
+            expect(doc.name).to.be.eq('sixth')
+            done()
+          })
+          .catch(done)
+      })
+    })
+
+    describe('removeCacheImage', () => {
+      it('call removeCacheImage() on given clip will remove the image', (done) => {
+        subject.all()
+          .then((docs) => {
+            const doc = docs[2]
+            const f = path.join(subject.cwd, doc.raw)
+            fs.access(f, fs.constants.R_OK | fs.constants.W_OK, (err) => {
+              if (err) {
+                done(err)
+              } else {
+                subject.removeCacheImage(doc)
+                  .then(() => {
+                    fs.access(f, fs.constants.R_OK | fs.constants.W_OK, (err) => {
+                      err ? done() : done(new Error(`File ${f} is not removed.`))
+                    })
+                  }).then(() => {
+                    //  create an empty file to avoid error message
+                    touch(f)
+                  })
+                  .catch(done)
+              }
+            })
+          })
+      })
+    })
+
+    describe('all', () => {
+      it('gives me all 5 items back', (done) => {
+        subject.all()
+        .then((docs) => {
+          expect(docs.length).to.eq(5)
+        })
+        .then(done)
+        .catch(done)
+      })
+
+      it('is in the correct order', (done) => {
+        subject.all()
+        .then((docs) => {
+          expect(docs[0].name).to.eq('fifth')
+          expect(docs[1].name).to.eq('fourth')
+          expect(docs[2].name).to.eq('third')
+          expect(docs[3].name).to.eq('second')
+          expect(docs[4].name).to.eq('first')
+        })
+        .then(() => done())
+        .catch(done)
+      })
+    })
+  })
+})

--- a/test/cappedCollection.spec.js
+++ b/test/cappedCollection.spec.js
@@ -1,90 +1,199 @@
 'use strict'
 
 const expect = require('chai').expect
-const CappedCollection = require('../src/lib/cappedCollection')
-const fs = require('fs')
 const path = require('path')
+const rmdir = require('rimraf')
+const CappedCollection = require('../src/lib/cappedCollection')
+
+const getTempDir = () => path.join(__dirname, 'tmp', `${Date.now()}`)
 
 let subject
 describe('CappedCollection', () => {
   describe('given a full capped collection of 5 items', () => {
-
     beforeEach((done) => {
-      subject = new CappedCollection('test_items', {
-        cwd: __dirname,
-      })
+      subject = new CappedCollection('test_items', { cwd: getTempDir() })
       subject.setSize(5)
       subject.upsert({ name: 'first', createdAt: new Date(new Date() - 9 * 1000) })
-        .then(() => {
-          return subject.upsert({ name: 'second', createdAt: new Date(new Date() - 8 * 1000) })
-        })
-        .then(() => {
-          return subject.upsert({ name: 'third', createdAt: new Date(new Date() - 7 * 1000) })
-        })
-        .then(() => {
-          return subject.upsert({ name: 'fourth', createdAt: new Date(new Date() - 6 * 1000) })
-        })
-        .then(() => {
-          return subject.upsert({ name: 'fifth', createdAt: new Date(new Date() - 5 * 1000) })
-        }).then(done)
+        .then(() => subject.upsert({ name: 'second', createdAt: new Date(new Date() - 8 * 1000) }))
+        .then(() => subject.upsert({ name: 'third', createdAt: new Date(new Date() - 7 * 1000) }))
+        .then(() => subject.upsert({ name: 'fourth', createdAt: new Date(new Date() - 6 * 1000) }))
+        .then(() => subject.upsert({ name: 'fifth', createdAt: new Date(new Date() - 5 * 1000) }))
+        .then(() => done())
+        .catch(done)
     })
 
     afterEach((done) => {
       subject.collection.remove({}, { multi: true }, () => {
-        subject.all().then((docs) => {
-          expect(docs.length).to.eq(0)
-        }).then(done).catch((err) => {
-          console.log(err, err.stack)
-        })
+        subject.all()
+          .then((docs) => {
+            expect(docs.length).to.eq(0)
+            rmdir(path.join(__dirname, 'tmp'), done)
+          })
+          .catch(done)
       })
     })
 
     describe('last', (done) => {
       it('gives me back the last item added', (done) => {
-        subject.last().then((doc) => {
-          expect(doc).to.include({
-            name: 'fifth'
+        subject.last()
+          .then((doc) => {
+            expect(doc).to.include({
+              name: 'fifth',
+            })
+            done()
           })
-        }).then(done).catch((err) => {
-          console.log(err, err.stack)
-        })
+          .catch(done)
       })
     })
 
     describe('remove', () => {
-      it('gives me back the last item added', (done) => {
-        subject.last().then((doc) => {
-          expect(doc.name).to.eq('fifth')
-          return subject.remove([doc._id])
-        }).then(() => {
-          return subject.last()
-        }).then((doc) => {
-          expect(doc.name).to.eq('fourth')
-        }).then(done).catch((err) => {
-          console.log(err, err.stack)
+      it('remove the last item added', (done) => {
+        subject.last()
+          .then((doc) => {
+            expect(doc.name).to.eq('fifth')
+            return subject.remove([doc._id])
+          })
+          .then(() => subject.last())
+          .then((doc) => {
+            expect(doc.name).to.eq('fourth')
+            done()
+          })
+          .catch(done)
+      })
+    })
+
+    describe('reduce', () => {
+      it('calling reduce() will remove extra items', (done) => {
+        subject.setSize(4)
+        subject.reduce()
+          .then((nums) => {
+            expect(nums).to.be.eq(1)
+            return subject.all()
+          })
+          .then((docs) => {
+            expect(docs.length).to.be.eq(4)
+            expect(docs[docs.length - 1].name).to.be.eq('second')
+            return subject.last()
+          })
+          .then((doc) => {
+            //  the last one shouldn't be removed
+            expect(doc.name).to.be.eq('fifth')
+            done()
+          })
+          .catch(done)
+      })
+      it('calling upsert() will trigger reduce() and remove extra items', (done) => {
+        subject.setSize(4)
+        subject.upsert({ name: 'sixth', createdAt: new Date(new Date() - 3 * 1000) })
+          .then((nums) => {
+            expect(nums).to.be.eq(2)
+            return subject.all()
+          })
+          .then((docs) => {
+            expect(docs.length).to.be.eq(4)
+            expect(docs[docs.length - 1].name).to.be.eq('third')
+            return subject.last()
+          })
+          .then((doc) => {
+            //  the last one should be the new one
+            expect(doc.name).to.be.eq('sixth')
+            done()
+          })
+          .catch(done)
+      })
+    })
+
+    describe('onRemove()', () => {
+      it('call callback() for given doc: [0] => fifth', (done) => {
+        subject.all()
+          .then((docs) => subject.handleOnRemove([docs[0]._id], (doc) => {
+            expect(doc.name).to.eq('fifth')
+            done()
+          }))
+          .catch(done)
+      })
+      it('call callback() for given doc: [2] => third', (done) => {
+        subject.all()
+          .then((docs) => subject.handleOnRemove([docs[0]._id], (doc) => {
+            expect(doc.name).to.eq('fifth')
+            done()
+          }))
+          .catch(done)
+      })
+      it('call callback() for given doc: [4] => first', (done) => {
+        subject.all()
+          .then((docs) => subject.handleOnRemove([docs[0]._id], (doc) => {
+            expect(doc.name).to.eq('fifth')
+            done()
+          }))
+          .catch(done)
+      })
+      it('call callback() for given docs', (done) => {
+        let count = 0
+        subject.all()
+          .then((docs) => subject.handleOnRemove([docs[0]._id, docs[2]._id, docs[4]._id], (doc) => {
+            expect(doc.name === 'first' || doc.name === 'third' || doc.name === 'fifth').to.be.true
+            ++count
+          }))
+          .then((ids) => {
+            expect(ids.length).to.be.eq(3)
+            expect(count).to.be.eq(3)
+            done()
+          })
+          .catch(done)
+      })
+      it('remove() will call the given callback function', (done) => {
+        subject.setOnRemove((doc) => {
+          expect(doc.name).to.be.eq('fifth')
         })
+        subject.all()
+          .then((docs) => subject.remove([docs[0]._id]))
+          .then((nums) => {
+            expect(nums).to.be.eq(1)
+            subject.clearOnRemove()
+            done()
+          })
+          .catch(done)
+      })
+      it('remove() will call the given callback function multiple times for multiple ids', (done) => {
+        let count = 0
+        subject.setOnRemove((doc) => {
+          expect(doc.name === 'fifth' || doc.name === 'third' || doc.name === 'second').to.be.true
+          ++count
+        })
+        subject.all()
+          .then((docs) => subject.remove([docs[0]._id, docs[2]._id, docs[3]._id]))
+          .then((nums) => {
+            expect(nums).to.be.eq(3)
+            expect(count).to.be.eq(3)
+            subject.clearOnRemove()
+            done()
+          })
+          .catch(done)
       })
     })
 
     describe('all', () => {
       it('gives me all 5 items back', (done) => {
-        subject.all().then((docs) => {
-          expect(docs.length).to.eq(5)
-        }).then(done).catch((err) => {
-          console.log(err, err.stack)
-        })
+        subject.all()
+          .then((docs) => {
+            expect(docs.length).to.eq(5)
+          })
+          .then(() => done())
+          .catch(done)
       })
 
       it('is in the correct order', (done) => {
-        subject.all().then((docs) => {
-          expect(docs[0].name).to.eq('fifth')
-          expect(docs[1].name).to.eq('fourth')
-          expect(docs[2].name).to.eq('third')
-          expect(docs[3].name).to.eq('second')
-          expect(docs[4].name).to.eq('first')
-        }).then(done).catch((err) => {
-          console.log(err, err.stack)
-        })
+        subject.all()
+          .then((docs) => {
+            expect(docs[0].name).to.eq('fifth')
+            expect(docs[1].name).to.eq('fourth')
+            expect(docs[2].name).to.eq('third')
+            expect(docs[3].name).to.eq('second')
+            expect(docs[4].name).to.eq('first')
+          })
+          .then(() => done())
+          .catch(done)
       })
     })
   })

--- a/test/present.spec.js
+++ b/test/present.spec.js
@@ -3,8 +3,8 @@ const present = require('../src/lib/present')
 
 const clips = {
   short_hex: { _id: 1, type: 'text', raw: '#fff', createdAt: new Date() },
-  long_hex:  { _id: 2, type: 'text', raw: '#000000', createdAt: new Date() },
-  word:      { _id: 3, type: 'text', raw: 'Quadrupoles', createdAt: new Date() },
+  long_hex: { _id: 2, type: 'text', raw: '#000000', createdAt: new Date() },
+  word: { _id: 3, type: 'text', raw: 'Quadrupoles', createdAt: new Date() },
 }
 
 describe('Present', () => {


### PR DESCRIPTION
As 'nedb' cannot handle large database (e.g. more than 250MB), store the
image inside database will have significant impact on performance, even
usability. (For my case, the database exceed 380MB, which caused `zazu-clipboard` stopped working.)

To reduce such impact, this PR stores the clipboard images externally in the cache
directory, 'data/images'.

This PR also improved the performance by using hash (sha1) for the clipboard change detection, which increase the performance a lot. (1000ms => 20-30 ms if it's a photo).

Also fixed the 'unitName' case to upper case.

Signed-off-by: Tao Wang <twang2218@gmail.com>