### PR TITLE
Fix dependancy import

### DIFF
--- a/src/lib/present.js
+++ b/src/lib/present.js
@@ -1,4 +1,4 @@
-const ago = require('s-ago').default
+const ago = require('s-ago')
 const Color = require('color')
 const { htmlEncode } = require('js-htmlencode')
 const path = require('path')


### PR DESCRIPTION
In a recent change `s-ago` is no longer exporting through `default`, but instead it's exporting the function directly.
This should fix issue #21