### PR TITLE
fix: paste image from file path

### DIFF
--- a/src/copy.js
+++ b/src/copy.js
@@ -1,8 +1,9 @@
+const path = require('path')
 const CappedClient = require('./lib/cappedClient')
 const { clipboard, nativeImage } = require('electron')
 
 /**
- * Given an id, coyp the data to the clipboard.
+ * Given an id, copy the data to the clipboard.
  */
 module.exports = (pluginContext) => {
   const { cwd } = pluginContext
@@ -13,7 +14,7 @@ module.exports = (pluginContext) => {
       if (clip.type === 'text') {
         clipboard.writeText(clip.raw)
       } else if (clip.type === 'image') {
-        const image = nativeImage.createFromDataURL(clip.raw)
+        const image = nativeImage.createFromPath(path.resolve(cwd, clip.raw))
         clipboard.writeImage(image)
       }
     })


### PR DESCRIPTION
`clip.raw` is the path to image file rather than the base64 data, so this feature does not actually work now.